### PR TITLE
Handle custom RC markers and extend tests

### DIFF
--- a/ai-switch.sh
+++ b/ai-switch.sh
@@ -45,11 +45,13 @@ _ai_extract_vars_from_block() {
 
 _ai_write_block_to_rc() {
   # $1: profile file path
-  local tmp
+  local tmp start_esc end_esc
   tmp="$(mktemp)"
   cp "$AI_RC_FILE" "${AI_RC_FILE}.bak.$(date +%Y%m%d%H%M%S)" 2>/dev/null || true
+  start_esc=$(printf '%s\n' "$AI_RC_START" | sed 's/[]\\/$*.^[]/\\&/g')
+  end_esc=$(printf '%s\n' "$AI_RC_END" | sed 's/[]\\/$*.^[]/\\&/g')
   if [ -f "$AI_RC_FILE" ]; then
-    sed '/^# >>> AI CONFIG START >>>$/,/^# <<< AI CONFIG END <<</{d}' "$AI_RC_FILE" >"$tmp"
+    sed "/^${start_esc}\$/,/^${end_esc}\$/{d}" "$AI_RC_FILE" >"$tmp"
   else
     : >"$tmp"
   fi

--- a/tests/test_basic.bats
+++ b/tests/test_basic.bats
@@ -22,3 +22,11 @@ setup() {
   [[ "$output" == *'export A=B'* ]]
   [[ "$output" == *'export C=D'* ]]
 }
+
+@test "switch works with custom markers" {
+  run env AI_RC_START='# [AI] START*' AI_RC_END='# [AI] END*' bash -lc 'source "$HOME/.ai-switch.sh"; ai switch demo; ai switch demo; echo "$FOO"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'bar'* ]]
+  [ "$(echo "$output" | grep -c 'Switched to: demo')" -eq 2 ]
+  [ "$(grep -c '# \\[AI\\] START\\*' "$HOME/.bashrc")" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
- escape and substitute `AI_RC_START`/`AI_RC_END` when updating the rc block so markers with special characters work
- add Bats test covering switching with custom markers

## Testing
- `make test` *(fails: bats: No such file or directory)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*
- `env AI_RC_START='# [AI] START*' AI_RC_END='# [AI] END*' bash -lc 'source "$HOME/.ai-switch.sh"; ai switch demo; ai switch demo; echo "$FOO"; grep -c "# \[AI\] START\*" "$HOME/.bashrc"'`

------
https://chatgpt.com/codex/tasks/task_e_6896f117db508332ac8d5a594824fc1c