### PR TITLE
Fix Makefile test target indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ lint:
 	test -d completion && shellcheck completion/* || true
 	test -d tests && echo OK
 
- test:
+test:
 	bats tests


### PR DESCRIPTION
## Summary
- align `test` target at column 1 in Makefile
- keep `bats tests` line tab-indented

## Testing
- `make test` *(fails: make: bats: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896f38923f88332be1f21ae8bc379fa