### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/ai-switch.sh
+++ b/ai-switch.sh
@@ -26,7 +26,7 @@ mkdir -p "$AI_PROFILES_DIR"
 
 # ------ helpers ------
 _ai_list_profiles() {
-  ls -1 "$AI_PROFILES_DIR" 2>/dev/null | grep -v '^\.current$' || true
+  find "$AI_PROFILES_DIR" -maxdepth 1 -type f ! -name '.current' -printf '%f\n' 2>/dev/null || true
 }
 
 _ai_current() {
@@ -87,7 +87,7 @@ _ai_write_profile_from_kv() {
   : >"$out"
   local kv
   for kv in "$@"; do
-    if expr match "$kv" '^[A-Za-z_][A-Za-z0-9_]*=' >/dev/null; then
+    if [[ $kv =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
       printf 'export %s\n' "$kv" >>"$out"
     else
       printf 'Ignored invalid: %s\n' "$kv" >&2

--- a/completion/ai.bash
+++ b/completion/ai.bash
@@ -1,20 +1,21 @@
 # bash completion for ai
 _ai_complete() {
+  # shellcheck disable=SC2034
   local cur prev words cword
   _init_completion || return
   local cmds="list current switch add edit doctor version"
   if [[ ${COMP_CWORD} -eq 1 ]]; then
-    COMPREPLY=( $(compgen -W "$cmds" -- "$cur") )
+    readarray -t COMPREPLY < <(compgen -W "$cmds" -- "$cur")
     return
   fi
   case ${COMP_WORDS[1]} in
     switch|edit)
       local profs
       profs=$(ai list 2>/dev/null | tail -n +2)
-      COMPREPLY=( $(compgen -W "$profs" -- "$cur") )
+      readarray -t COMPREPLY < <(compgen -W "$profs" -- "$cur")
       ;;
     add)
-      COMPREPLY=( $(compgen -W "--force --switch --from-current" -- "$cur") )
+      readarray -t COMPREPLY < <(compgen -W "--force --switch --from-current" -- "$cur")
       ;;
   esac
 }

--- a/install.sh
+++ b/install.sh
@@ -32,8 +32,10 @@ chmod 644 "$TARGET"
 if [ -z "$RC_FILE" ]; then
   if [ -n "${ZSH_VERSION:-}" ] || [ "${SHELL:-}" = "/bin/zsh" ]; then RC_FILE="$HOME/.zshrc"; else RC_FILE="$HOME/.bashrc"; fi
 fi
-if ! grep -q 'source "$HOME/.ai-switch.sh"' "$RC_FILE" 2>/dev/null; then
-  printf '\n# ai-switch\n[ -f "$HOME/.ai-switch.sh" ] && source "$HOME/.ai-switch.sh"\n' >>"$RC_FILE"
+pattern="source \"\$HOME/.ai-switch.sh\""
+line="[ -f \"\$HOME/.ai-switch.sh\" ] && source \"\$HOME/.ai-switch.sh\""
+if ! grep -q "$pattern" "$RC_FILE" 2>/dev/null; then
+  printf '\n# ai-switch\n%s\n' "$line" >>"$RC_FILE"
 fi
 
 echo "Installed to $TARGET"


### PR DESCRIPTION
## Summary
- clean shellcheck warnings in install script, main utility and completion

## Testing
- `make lint` *(fails: shellcheck: not found)*
- `make test` *(fails: Bats not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689700b106e8833283424120ff4785b1