### PR TITLE
feat(ci): add macOS and Windows environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - name: Configure git line endings
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
       - name: Install ShellCheck (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -33,6 +36,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - name: Configure git line endings
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
       - name: Install Bats (Ubuntu)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,21 +6,45 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - name: ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
-        with:
-          scandir: .
+      - name: Install ShellCheck (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Install ShellCheck (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install shellcheck
+      - name: Install ShellCheck (Windows)
+        if: matrix.os == 'windows-latest'
+        run: choco install shellcheck -y
+      - name: Run ShellCheck
+        run: shellcheck $(git ls-files '*.sh')
+        shell: bash
+
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - name: Install bats
+      - name: Install Bats (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y bats
+      - name: Install Bats (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install bats-core
+      - name: Install Bats (Windows)
+        if: matrix.os == 'windows-latest'
+        run: choco install bats -y
       - name: Run tests
-        run: |
-          bats tests
+        run: bats tests
+        shell: bash

--- a/ai-switch.sh
+++ b/ai-switch.sh
@@ -46,7 +46,7 @@ _ai_extract_vars_from_block() {
 _ai_write_block_to_rc() {
   # $1: profile file path
   local tmp
-  tmp="$(mktemp)"
+  tmp="$(mktemp 2>/dev/null || mktemp -t ai-switch)"
   cp "$AI_RC_FILE" "${AI_RC_FILE}.bak.$(date +%Y%m%d%H%M%S)" 2>/dev/null || true
   if [ -f "$AI_RC_FILE" ]; then
     sed '/^# >>> AI CONFIG START >>>$/,/^# <<< AI CONFIG END <<</{d}' "$AI_RC_FILE" >"$tmp"


### PR DESCRIPTION
## Summary
- run lint and tests across ubuntu, macOS and windows
- install shellcheck and bats per-platform in CI

## Testing
- `shellcheck $(git ls-files '*.sh')` *(fails: command not found)*
- `bats tests` *(fails: command not found)*
- `sudo apt-get install -y shellcheck bats` *(fails: Unable to locate package shellcheck; Unable to locate package bats)*

------
https://chatgpt.com/codex/tasks/task_e_68970a627b0c8332a2bc42bc7ef1cb2c