### PR TITLE
Ensure ai list works on non-GNU systems

### DIFF
--- a/ai-switch.sh
+++ b/ai-switch.sh
@@ -37,7 +37,8 @@ mkdir -p "$AI_PROFILES_DIR"
 # List all available profiles in the profiles directory
 # Returns: List of profile names, one per line
 _ai_list_profiles() {
-  find "$AI_PROFILES_DIR" -maxdepth 1 -type f ! -name '.current' -printf '%f\n' 2>/dev/null || true
+  find "$AI_PROFILES_DIR" -maxdepth 1 -type f ! -name '.current' 2>/dev/null \
+    | sed -e 's#.*/##' || true
 }
 
 # Display the currently active profile

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,6 +22,14 @@ cp ai-switch.sh "$TEST_HOME/.ai-switch.sh"
 # Test profile creation
 echo 'export TEST_VAR=test_value' > "$TEST_HOME/.ai-profiles/test-profile"
 
+# Ensure listing shows the created profile
+if HOME="$TEST_HOME" bash -c '. "$HOME/.ai-switch.sh"; ai list | grep -qx "test-profile"'; then
+    echo "✅ List shows profile"
+else
+    echo "❌ List did not include profile"
+    exit 1
+fi
+
 # Test basic script syntax and structure
 if HOME="$TEST_HOME" bash -n "$TEST_HOME/.ai-switch.sh"; then
     echo "✅ Basic functionality test passed"


### PR DESCRIPTION
## Summary
- Make `ai list` portable by replacing GNU-specific `find -printf` with a `find`+`sed` pipeline
- Add test verifying that profile listing includes created profile

## Testing
- `bash scripts/lint.sh`
- `bash scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68996686a6548332ad9e945e133e9852