### PR TITLE
fix: list profiles reliably

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ ai doctor
 ai version
 ```
 
+Profiles are stored in `$AI_PROFILES_DIR` (defaults to `~/.ai-profiles`).
+
 ## Why?
 - Stop commenting/uncommenting blocks in `~/.bashrc`.
 - Keep clean, portable `export`-only profiles.

--- a/ai-switch.sh
+++ b/ai-switch.sh
@@ -37,8 +37,15 @@ mkdir -p "$AI_PROFILES_DIR"
 # List all available profiles in the profiles directory
 # Returns: List of profile names, one per line
 _ai_list_profiles() {
-  find "$AI_PROFILES_DIR" -maxdepth 1 -type f ! -name '.current' 2>/dev/null \
-    | sed -e 's#.*/##' || true
+  [ -d "$AI_PROFILES_DIR" ] || return 0
+  local f base
+  for f in "$AI_PROFILES_DIR"/*; do
+    [ -e "$f" ] || continue
+    [ -f "$f" ] || continue
+    base="$(basename "$f")"
+    [ "$base" = ".current" ] && continue
+    printf '%s\n' "$base"
+  done | sort
 }
 
 # Display the currently active profile
@@ -201,7 +208,12 @@ _ai_version() { echo "ai-switch 0.1.1"; }
 ai() {
   local cmd="${1:-}"; shift || true
   case "$cmd" in
-    list|"") echo "Available profiles:"; _ai_list_profiles ;;
+    list|"")
+      echo "Available profiles:"
+      local profiles
+      profiles="$(_ai_list_profiles)"
+      [ -n "$profiles" ] && printf '%s\n' "$profiles"
+      ;;
     current) echo "Current profile: $(_ai_current)" ;;
     version|--version|-v) _ai_version ;;
     switch)

--- a/ai-switch.sh
+++ b/ai-switch.sh
@@ -39,7 +39,7 @@ mkdir -p "$AI_PROFILES_DIR"
 _ai_list_profiles() {
   [ -d "$AI_PROFILES_DIR" ] || return 0
   local f base
-  for f in "$AI_PROFILES_DIR"/*; do
+  for f in "$AI_PROFILES_DIR"/* "$AI_PROFILES_DIR"/.*; do
     [ -e "$f" ] || continue
     [ -f "$f" ] || continue
     base="$(basename "$f")"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,6 +19,14 @@ TEST_HOME="./test-temp-$$"
 mkdir -p "$TEST_HOME/.ai-profiles"
 cp ai-switch.sh "$TEST_HOME/.ai-switch.sh"
 
+# Ensure listing handles no profiles
+if [ -z "$(HOME="$TEST_HOME" bash -c '. "$HOME/.ai-switch.sh"; ai list | sed -n 2p')" ]; then
+    echo "✅ Empty list handled"
+else
+    echo "❌ Empty list not handled"
+    exit 1
+fi
+
 # Test profile creation
 echo 'export TEST_VAR=test_value' > "$TEST_HOME/.ai-profiles/test-profile"
 


### PR DESCRIPTION
## Summary
- ensure `ai list` finds profiles using portable globbing
- remove placeholder warning when no profiles exist
- document default profile directory

## Testing
- `bash scripts/lint.sh`
- `bash scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68996edace1883328ff01e0d504df157