### PR TITLE
Add CI workflow for project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Run lint
+        run: bash scripts/lint.sh
+      - name: Run tests
+        run: bash scripts/test.sh


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run lint and tests with shellcheck

## Testing
- `bash scripts/lint.sh`
- `bash scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899895c609c8332a9d65b5eb894eb5c