### PR TITLE
Add status and checkout command aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Instantly switch AI provider environment profiles in your shell.
 ## Usage
 ```
 ai list
-ai current
-ai switch <profile>          # fzf-enabled if installed
+ai current | ai status
+ai switch <profile> | ai checkout <profile>          # fzf-enabled if installed
 ai add <name>                # open template in $EDITOR
 ai add <name> KEY=VAL ...    # quick create
 ai add <name> --from-current # snapshot rc AI block

--- a/ai-switch.sh
+++ b/ai-switch.sh
@@ -221,7 +221,7 @@ ai() {
       if [ -z "$name" ] && command -v fzf >/dev/null 2>&1; then
         name="$(_ai_list_profiles | fzf --prompt='Select AI profile> ' --height=40% --reverse)"
       fi
-      if [ -z "$name" ]; then echo "Usage: ai switch <profile> (or: ai checkout <profile>)"; return 1; fi
+      if [ -z "$name" ]; then echo "Usage: ai $cmd <profile>"; return 1; fi
       if ! _ai_validate_name "$name"; then echo "Invalid profile name: $name"; return 1; fi
       local file; file="$(_ai_profile_path "$name")"
       if [ ! -f "$file" ]; then echo "Not found: $file"; return 1; fi

--- a/ai-switch.sh
+++ b/ai-switch.sh
@@ -314,7 +314,7 @@ EOF
       cat <<'EOF'
 Usage:
   ai list                   List profiles
-  ai current | ai status     Show current profile
+  ai current | ai status    Show current profile
   ai switch <profile>       Switch (fzf-enabled if installed)
   ai checkout <profile>     Alias for 'ai switch'
   ai add <name> [opts]      Add new profile (template/kv/from-current)

--- a/ai-switch.sh
+++ b/ai-switch.sh
@@ -214,14 +214,14 @@ ai() {
       profiles="$(_ai_list_profiles)"
       [ -n "$profiles" ] && printf '%s\n' "$profiles"
       ;;
-    current) echo "Current profile: $(_ai_current)" ;;
+    current|status) echo "Current profile: $(_ai_current)" ;;
     version|--version|-v) _ai_version ;;
-    switch)
+    switch|checkout)
       local name="${1:-}"
       if [ -z "$name" ] && command -v fzf >/dev/null 2>&1; then
         name="$(_ai_list_profiles | fzf --prompt='Select AI profile> ' --height=40% --reverse)"
       fi
-      if [ -z "$name" ]; then echo "Usage: ai switch <profile>"; return 1; fi
+      if [ -z "$name" ]; then echo "Usage: ai switch <profile> (or: ai checkout <profile>)"; return 1; fi
       if ! _ai_validate_name "$name"; then echo "Invalid profile name: $name"; return 1; fi
       local file; file="$(_ai_profile_path "$name")"
       if [ ! -f "$file" ]; then echo "Not found: $file"; return 1; fi
@@ -314,8 +314,9 @@ EOF
       cat <<'EOF'
 Usage:
   ai list                   List profiles
-  ai current                Show current profile
+  ai current | ai status     Show current profile
   ai switch <profile>       Switch (fzf-enabled if installed)
+  ai checkout <profile>     Alias for 'ai switch'
   ai add <name> [opts]      Add new profile (template/kv/from-current)
   ai remove <profile>       Remove profile file (clears if current)
   ai edit <profile>         Edit profile file

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -39,6 +39,22 @@ else
     exit 1
 fi
 
+# Test alias: status
+if HOME="$TEST_HOME" bash -c '. "$HOME/.ai-switch.sh"; ai status | grep -qx "Current profile: (none)"'; then
+    echo "✅ status alias works"
+else
+    echo "❌ status alias failed"
+    exit 1
+fi
+
+# Test alias: checkout
+if HOME="$TEST_HOME" bash -c '. "$HOME/.ai-switch.sh"; ai checkout test-profile; ai status | grep -qx "Current profile: test-profile"'; then
+    echo "✅ checkout alias works"
+else
+    echo "❌ checkout alias failed"
+    exit 1
+fi
+
 # Test basic script syntax and structure
 if HOME="$TEST_HOME" bash -n "$TEST_HOME/.ai-switch.sh"; then
     echo "✅ Basic functionality test passed"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -39,19 +39,20 @@ else
     exit 1
 fi
 
-# Test alias: status
-if HOME="$TEST_HOME" bash -c '. "$HOME/.ai-switch.sh"; ai status | grep -qx "Current profile: (none)"'; then
-    echo "✅ status alias works"
-else
-    echo "❌ status alias failed"
-    exit 1
-fi
+# Test aliases
+if HOME="$TEST_HOME" bash -c '
+    . "$HOME/.ai-switch.sh"
+    
+    # Test status alias
+    ai status | grep -qx "Current profile: (none)" || exit 1
 
-# Test alias: checkout
-if HOME="$TEST_HOME" bash -c '. "$HOME/.ai-switch.sh"; ai checkout test-profile; ai status | grep -qx "Current profile: test-profile"'; then
-    echo "✅ checkout alias works"
+    # Test checkout alias
+    ai checkout test-profile
+    ai status | grep -qx "Current profile: test-profile" || exit 1
+'; then
+    echo "✅ status and checkout aliases work"
 else
-    echo "❌ checkout alias failed"
+    echo "❌ alias tests failed"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add `ai status` alias for viewing the current profile
- Add `ai checkout` alias for switching profiles
- Document and test the new aliases

## Testing
- `sh scripts/lint.sh`
- `sh scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c3f23cf4c833299977e6a0082eeb4